### PR TITLE
Update tl_content.php

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -238,7 +238,7 @@ class tl_content_tabcontrol extends \Contao\Backend
         }
 
         // Return all gallery templates
-        return $this->getTemplateGroup('ce_tabcontrol_' . $templateSnip, $objLayout->pid);
+        return $this->getTemplateGroup('ce_tabcontrol_' . $templateSnip, [$objLayout->pid]);
     }
 
 


### PR DESCRIPTION
Contao\Controller::getTemplateGroup() accepts only type of array as second parameter.

This solves https://github.com/christianbarkowsky/contao-tabcontrol/issues/41